### PR TITLE
migration to catkin_make 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,94 @@
-cmake_minimum_required(VERSION 2.4.6)
-include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
+# Copyright (C) 2008-2013 LAAS-CNRS, JRL AIST-CNRS.
+#
+# Author: Florent Lamiraux, Nirmal Giftsun
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Catkin part
+
+cmake_minimum_required(VERSION 2.4.6)
+
+project(dynamic_graph_bridge)
+
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs message_generation std_srvs geometry_msgs sensor_msgs tf realtime_tools)
+find_package(Boost REQUIRED COMPONENTS program_options)
+
+add_message_files(FILES Matrix.msg Vector.msg)
+
+add_service_files(FILES  RunCommand.srv)
+
+generate_messages(
+  DEPENDENCIES
+  dynamic_graph_bridge
+  std_msgs
+)
+catkin_package(CATKIN_DEPENDS message_runtime)
+
+
+## LAAS cmake submodule part
+set(PROJECT_DESCRIPTION "Dynamic graph bridge library")
+set(PROJECT_NAME dynamic_graph_bridge)
+set(PROJECT_URL "")
+
+set(CXX_DISABLE_WERROR False)
+set(CUSTOM_HEADER_DIR dynamic_graph_bridge)
+set(${PROJECT_NAME}_HEADERS
+  include/dynamic_graph_bridge/ros_init.hh
+  include/dynamic_graph_bridge/ros_interpreter.hh
+  )
 include(cmake/base.cmake)
 include(cmake/GNUInstallDirs.cmake)
+include(cmake/python.cmake)
 
-set(ROS_BUILD_TYPE RelWithDebInfo)
-
-rosbuild_init()
+SETUP_PROJECT()
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 set(CMAKE_INSTALL_RPATH "${LIBRARY_OUTPUT_PATH}")
-
-rosbuild_genmsg()
-rosbuild_gensrv()
-
-rosbuild_add_boost_directories()
-
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${LIBRARY_OUTPUT_PATH}")
 set(PKG_CONFIG_ADDITIONAL_VARIABLES
   ${PKG_CONFIG_ADDITIONAL_VARIABLES}
   plugindirname
   plugindir
   )
 
+add_required_dependency(roscpp)
+add_required_dependency("realtime_tools >= 1.8")
 add_required_dependency(bullet)
-
 add_required_dependency(jrl-mal)
 add_required_dependency(dynamic-graph)
 add_required_dependency(dynamic-graph-python)
 add_required_dependency(sot-core)
 add_required_dependency(sot-dynamic)
 
-include_directories(include)
-
-rosbuild_add_library(ros_bridge
+add_library(ros_bridge
   src/converter.hh
   include/dynamic_graph_bridge/ros_init.hh src/ros_init.cpp
   src/sot_to_ros.hh src/sot_to_ros.cpp
   )
+
+pkg_config_use_dependency(ros_bridge jrl-mal)
 pkg_config_use_dependency(ros_bridge bullet)
+
 # Make sure rpath are preserved during the install as ROS dependencies
 # are not installed.
 set_target_properties(ros_bridge PROPERTIES BUILD_WITH_INSTALL_RPATH True)
 
 macro(compile_plugin NAME)
+  message(lib path ${LIBRARY_OUTPUT_PATH})
   file(MAKE_DIRECTORY "${LIBRARY_OUTPUT_PATH}/dynamic_graph/ros/${NAME}")
-  rosbuild_add_library(${NAME} src/${NAME}.cpp src/${NAME}.hh)
+  add_library(${NAME} src/${NAME}.cpp src/${NAME}.hh)
   pkg_config_use_dependency(${NAME} jrl-mal)
   pkg_config_use_dependency(${NAME} dynamic-graph)
   pkg_config_use_dependency(${NAME} sot-core)
@@ -53,12 +96,14 @@ macro(compile_plugin NAME)
   target_link_libraries(${NAME} ros_bridge)
   set_target_properties(${NAME} PROPERTIES BUILD_WITH_INSTALL_RPATH True)
   install(TARGETS ${NAME} DESTINATION lib)
+  
 
   dynamic_graph_python_module("ros/${NAME}"
     ${NAME}
     ros/${NAME}/wrap
     )
 
+  PKG_CONFIG_USE_DEPENDENCY(ros/${NAME}/wrap realtime_tools)
   PKG_CONFIG_USE_DEPENDENCY(ros/${NAME}/wrap jrl-mal)
   PKG_CONFIG_USE_DEPENDENCY(ros/${NAME}/wrap dynamic_graph)
   PKG_CONFIG_USE_DEPENDENCY(ros/${NAME}/wrap sot-core)
@@ -66,30 +111,30 @@ endmacro()
 
 include(cmake/python.cmake)
 
-include_directories(${DYNAMIC_GRAPH_include_DIRS})
-link_directories(${DYNAMIC_GRAPH_LIBRARY_DIRS})
-
 compile_plugin(ros_publish)
 compile_plugin(ros_subscribe)
 compile_plugin(ros_time)
-
 compile_plugin(ros_joint_state)
+
 target_link_libraries(ros_joint_state "${DYNAMIC_GRAPH_PLUGINDIR}/dynamic.so")
 
 compile_plugin(robot_model)
 
 # ros_interperter library.
-rosbuild_add_library(ros_interpreter src/ros_interpreter.cpp)
+add_library(ros_interpreter src/ros_interpreter.cpp)
 pkg_config_use_dependency(ros_interpreter jrl-mal)
 pkg_config_use_dependency(ros_interpreter dynamic-graph)
 pkg_config_use_dependency(ros_interpreter sot-core)
+pkg_config_use_dependency(ros_interpreter roscpp)
+
 add_dependencies(ros_interpreter ros_bridge)
 target_link_libraries(ros_interpreter ros_bridge)
 set_target_properties(ros_interpreter PROPERTIES BUILD_WITH_INSTALL_RPATH True)
+message(cmakeinstalllibdir ${CMAKE_INSTALL_LIBDIR} )
 install(TARGETS ros_interpreter DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Stand alone remote dynamic-graph Python interpreter.
-rosbuild_add_executable(interpreter src/interpreter.cpp)
+add_executable(interpreter src/interpreter.cpp)
 add_dependencies(interpreter ros_interpreter)
 target_link_libraries(interpreter ros_interpreter)
 pkg_config_use_dependency(interpreter jrl-mal)
@@ -100,14 +145,11 @@ pkg_config_use_dependency(interpreter sot-dynamic)
 #install(TARGETS interpreter DESTINATION bin)
 
 # Stand alone embedded intepreter with a robot controller.
-rosbuild_add_executable(geometric_simu src/geometric_simu.cpp src/sot_loader.cpp)
-rosbuild_link_boost(geometric_simu program_options)
+add_executable(geometric_simu src/geometric_simu.cpp src/sot_loader.cpp)
+pkg_config_use_dependency(geometric_simu roscpp)
+target_link_libraries(geometric_simu  ${Boost_LIBRARIES})
 
 add_subdirectory(src)
 
-# Print warning.
-MESSAGE(STATUS "=====================================================")
-MESSAGE(STATUS "WARNING: this package has an 'install' target.")
-MESSAGE(STATUS "Always run 'make install' in the package directory to")
-MESSAGE(STATUS "properly install the Python modules and entities.")
-MESSAGE(STATUS "=====================================================")
+SETUP_PROJECT_FINALIZE()
+

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,49 @@
+<package>
+  <name>dynamic_graph_bridge</name>
+  <version>2.0.0</version>
+  <description>
+
+    URDF parser for jrl-dynamics
+
+  </description>
+  <maintainer email="hpp@laas.fr">hpp@laas.fr</maintainer>
+  <author email="hpp@laas.fr">hpp@laas.fr</author>
+
+  <license>LGPL</license>
+  <url>http://ros.org/wiki/jrl_dynamics_urdf</url>
+
+  <export>
+    <cpp
+       cflags="-I${prefix}/include"
+       lflags="-L${prefix}/lib -lros_bridge -lros_interpreter -Wl,-rpath,${prefix}/lib"
+       />
+    <rosdoc config="rosdoc.yaml" />
+  </export>
+
+  <buildtool_depend>catkin</buildtool_depend> 
+
+  <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>realtime_tools</build_depend>
+  <build_depend>jrl_dynamics_urdf</build_depend>
+<build_depend>message_generation</build_depend>
+
+
+  <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>realtime_tools</run_depend>
+  <run_depend>jrl_dynamics_urdf</run_depend>
+  <run_depend>message_runtime</run_depend>
+
+
+
+
+</package>


### PR DESCRIPTION
The changes let the user execute both
- catkin_make which is run in the root of the catkin workspace
- 'make install'  which is run in project source directory

Please let me know if anything needs to be checked/modified/updated
