### PR TITLE
Include runPythonFile service

### DIFF
--- a/include/dynamic_graph_bridge/ros_interpreter.hh
+++ b/include/dynamic_graph_bridge/ros_interpreter.hh
@@ -2,6 +2,7 @@
 # define DYNAMIC_GRAPH_BRIDGE_INTERPRETER_HH
 # include <ros/ros.h>
 # include <dynamic_graph_bridge/RunCommand.h>
+# include <dynamic_graph_bridge/RunPythonFile.h>
 # include <dynamic-graph/python/interpreter.hh>
 
 namespace dynamicgraph
@@ -20,6 +21,11 @@ namespace dynamicgraph
     	  dynamic_graph_bridge::RunCommand::Response&)>
     runCommandCallback_t;
 
+    typedef boost::function<
+    bool (dynamic_graph_bridge::RunPythonFile::Request&,
+          dynamic_graph_bridge::RunPythonFile::Response&)>
+    runPythonFileCallback_t;
+
     explicit Interpreter (ros::NodeHandle& nodeHandle);
 
     /// \brief Run a command and return result.
@@ -29,6 +35,10 @@ namespace dynamicgraph
     void runCommand(const std::string & command, std::string &result,
 		    std::string &out, std::string &err);
 
+    /// \brief Method to parse python scripts.
+    /// \param Input file name to parse.
+    void runPythonFile(std::string ifilename);
+
     /// Initialize service run_command
     void startRosService ();
 
@@ -37,10 +47,15 @@ namespace dynamicgraph
     bool runCommandCallback (dynamic_graph_bridge::RunCommand::Request& req,
 			     dynamic_graph_bridge::RunCommand::Response& res);
 
+    /// \brief Run a Python file.
+    bool runPythonFileCallback (dynamic_graph_bridge::RunPythonFile::Request& req,
+                                dynamic_graph_bridge::RunPythonFile::Response& res);
+
   private:
     python::Interpreter interpreter_;
     ros::NodeHandle& nodeHandle_;
     ros::ServiceServer runCommandSrv_;
+    ros::ServiceServer runPythonFileSrv_;
   };
 } // end of namespace dynamicgraph.
 

--- a/scripts/run_command
+++ b/scripts/run_command
@@ -19,7 +19,9 @@ class RosShell(InteractiveConsole):
         rospy.wait_for_service('run_command')
         self.client = rospy.ServiceProxy(
             'run_command', dynamic_graph_bridge.srv.RunCommand, True)
-
+        rospy.wait_for_service('run_script')
+        self.scriptClient = rospy.ServiceProxy(
+            'run_script', dynamic_graph_bridge.srv.RunPythonFile, True)
 
     def runcode(self, code, retry = True):
         source = self.cache[:-1]
@@ -69,6 +71,8 @@ class RosShell(InteractiveConsole):
 if __name__ == '__main__':
     import optparse
     manifest = roslib.manifest.load_manifest('dynamic_graph_bridge')
+    rospy.init_node('run_command', argv=sys.argv)
+    sys.argv = rospy.myargv(argv=None)
     parser = optparse.OptionParser(
         usage='\n\t%prog [options]',
         version='%%prog %s' % manifest.version)
@@ -82,12 +86,8 @@ if __name__ == '__main__':
         if not sh.client:
             print("Connection to remote server has been lost.")
             sys.exit(1)
-        response = sh.client(str(source))
-        if response.stdout != "":
-            print response.stdout[:-1]
-            if response.stderr != "":
-                print response.stderr[:-1]
-            elif response.result != "None":
-                print response.result
+        response = sh.scriptClient(infile)
+        if not response:
+            print("Error while file parsing ")
     else:
         sh.interact("Interacting with remote server.")

--- a/src/ros_interpreter.cpp
+++ b/src/ros_interpreter.cpp
@@ -7,7 +7,8 @@ namespace dynamicgraph
   Interpreter::Interpreter (ros::NodeHandle& nodeHandle)
     : interpreter_ (),
       nodeHandle_ (nodeHandle),
-      runCommandSrv_ ()
+      runCommandSrv_ (),
+      runPythonFileSrv_ ()
   {
   }
 
@@ -17,6 +18,11 @@ namespace dynamicgraph
       boost::bind (&Interpreter::runCommandCallback, this, _1, _2);
     runCommandSrv_ =
       nodeHandle_.advertiseService ("run_command", runCommandCb);
+
+    runPythonFileCallback_t runPythonFileCb =
+      boost::bind (&Interpreter::runPythonFileCallback, this, _1, _2);
+    runPythonFileSrv_ =
+      nodeHandle_.advertiseService ("run_script", runPythonFileCb);
   }
 
   bool
@@ -25,6 +31,15 @@ namespace dynamicgraph
    dynamic_graph_bridge::RunCommand::Response& res)
   {
     interpreter_.python(req.input, res.result, res.stdout, res.stderr);
+    return true;
+  }
+
+  bool
+  Interpreter::runPythonFileCallback (dynamic_graph_bridge::RunPythonFile::Request& req,
+                                      dynamic_graph_bridge::RunPythonFile::Response& res)
+  {
+    interpreter_.runPythonFile(req.input);
+    res.result = "File parsed"; // FIX: It is just an echo, is there a way to have a feedback?
     return true;
   }
 
@@ -42,6 +57,10 @@ namespace dynamicgraph
    std::string &err)
   {
     interpreter_.python(command, result, out, err);
+  }
+
+  void Interpreter::runPythonFile( std::string ifilename ){
+      interpreter_.runPythonFile(ifilename);
   }
 
 } // end of namespace dynamicgraph.

--- a/srv/RunPythonFile.srv
+++ b/srv/RunPythonFile.srv
@@ -1,0 +1,3 @@
+string input
+---
+string result


### PR DESCRIPTION
This enables to directly launch a python file within any roslaunch file

we introduced a second service next to "runCommand", called "runPythonFile" which takes a complete python script and parses it. This enables us to setup the dynamic-graph and SoT as a single include line in any of our roslaunch files. This can for example load the complete environment and is then accessible via the python_interpreter.

example:

``` xml
<node name="run_command" pkg="dynamic_graph_bridge" type="run_command" ns="sot_controller" args="$(find sot_controller)/python_code/demo/demo_dynamic_velocity_damping.py" output="screen"/>
```
