### PR TITLE
Install headers and library to use class RosRobotModel from c++ code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ macro(compile_plugin NAME)
   target_link_libraries(${NAME} ros_bridge)
   set_target_properties(${NAME} PROPERTIES BUILD_WITH_INSTALL_RPATH True)
   install(TARGETS ${NAME} DESTINATION lib)
+
+  # DelPrete: install header files
+  set(${NAME}_HEADERS src/${NAME}.hh)
+  #message(headers ${${NAME}_HEADERS})
+  install(FILES ${${NAME}_HEADERS} DESTINATION include/${PROJECT_NAME})
   
 
   dynamic_graph_python_module("ros/${NAME}"
@@ -131,7 +136,7 @@ add_dependencies(ros_interpreter ros_bridge)
 target_link_libraries(ros_interpreter ros_bridge)
 set_target_properties(ros_interpreter PROPERTIES BUILD_WITH_INSTALL_RPATH True
                       LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
-message(cmakeinstalllibdir ${CMAKE_INSTALL_LIBDIR} )
+#message(cmakeinstalllibdir ${CMAKE_INSTALL_LIBDIR} )
 install(TARGETS ros_interpreter DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Stand alone remote dynamic-graph Python interpreter.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,31 @@
 PYTHON_INSTALL("dynamic_graph/ros" "__init__.py" "${PYTHON_SITELIB}")
 PYTHON_INSTALL("dynamic_graph/ros" "ros.py" "${PYTHON_SITELIB}")
+
+# DelPrete: add main library
+#SET(sources   converter.hh        robot_model.hh    ros_joint_state.hh
+#              ros_publish.hh      ros_subscribe.hh  ros_time.hh
+#              sot_loader.hh       sot_to_ros.hh
+#              geometric_simu.cpp  robot_model.cpp  ros_interpreter.cpp
+#              ros_publish.cpp     ros_time.cpp     sot_to_ros.cpp
+#              interpreter.cpp     ros_init.cpp     ros_joint_state.cpp
+#              ros_subscribe.cpp   sot_loader.cpp )
+SET(sources   robot_model.hh     robot_model.cpp)
+SET(LIBRARY_NAME ${PROJECT_NAME})
+ADD_LIBRARY(${LIBRARY_NAME} SHARED ${sources})
+
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME} sot-core)
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME} sot-dynamic)
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME} dynamic-graph)
+
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} jrl-mal)
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} sot-core)
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} sot-dynamic)
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} dynamic-graph)
+PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} jrl-dynamics-urdf)
+
+set_target_properties(${LIBRARY_NAME} PROPERTIES BUILD_WITH_INSTALL_RPATH True)
+
+# Do not use ${CMAKE_INSTALL_LIBDIR} because it is not set to "lib"
+INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+# headers are already installed
+


### PR DESCRIPTION
The CMakeList.txt was not installing the header files and it was not generating the c++ library because these classes were only used through python bindings. Since I want to use them from c++ code, I added the necessary instructions to install the headers and the c++ library (in particular I am interested in the class RosRobotModel).
