### PR TITLE
 [python] Add history + completion to run_command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ before_install:
 - docker run dyngb-trusty:latest sudo git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
 
 script:
-- docker exec dyngb-trusty sudo make /build
-- docker exec dyngb-trusty sudo cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
-- docker exec dyngb-trusty sudo cmake /build
+- docker exec dyngb-trusty:latest sudo make /build
+- docker exec dyngb-trusty:latest sudo cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
+- docker exec dyngb-trusty:latest sudo cmake /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+  - docker
+
+before_install:
+- docker pull ros
+- docker run ros /bin/sh -c "sudo sh -c \"echo \"deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list \""
+- docker run ros /bin/sh -c "sudo sh -c \"echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list \""
+- docker run ros /bin/sh -c "curl http://robotpkg.openrobots.org/wip/packages/debian/robotpkg.key | sudo apt-key add -"
+- docker run ros /bin/sh -c "curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ services:
 
 before_install:
 - docker build -t dyngb-trusty -f ./travis_custom/Dockerfile .
-- docker exec build git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
+- docker exec dyngb-trusty git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
 
 script:
-- docker exec build make /build
-- docker exec build cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
-- docker exec build cmake /build
+- docker exec dyngb-trusty make /build
+- docker exec dyngb-trusty cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
+- docker exec dyngb-trusty cmake /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ services:
   - docker
 
 before_install:
-- docker pull ros
-- docker run ros /bin/sh -c "sudo sh -c \"echo \"deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list \""
-- docker run ros /bin/sh -c "sudo sh -c \"echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list \""
-- docker run ros /bin/sh -c "curl http://robotpkg.openrobots.org/wip/packages/debian/robotpkg.key | sudo apt-key add -"
-- docker run ros /bin/sh -c "curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -"
+- docker build -t dyngb-trusty -f ./travis_custom/Dockerfile .
+- docker exec build git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
+
+script:
+- docker exec build make /build
+- docker exec build cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
+- docker exec build cmake /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ services:
 
 before_install:
 - docker build -t dyngb-trusty -f ./travis_custom/Dockerfile .
-- docker run dyngb-trusty:latest git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
+- docker run dyngb-trusty:latest sudo git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
 
 script:
-- docker exec dyngb-trusty make /build
-- docker exec dyngb-trusty cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
-- docker exec dyngb-trusty cmake /build
+- docker exec dyngb-trusty sudo make /build
+- docker exec dyngb-trusty sudo cmake -DCMAKE_SOURCE_DIR=/repo -DCMAKE_BINARY_DIR=/build
+- docker exec dyngb-trusty sudo cmake /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 before_install:
 - docker build -t dyngb-trusty -f ./travis_custom/Dockerfile .
-- docker run  dyngb-trusty git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
+- docker run dyngb-trusty:latest git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
 
 script:
 - docker exec dyngb-trusty make /build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 before_install:
 - docker build -t dyngb-trusty -f ./travis_custom/Dockerfile .
-- docker exec dyngb-trusty git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
+- docker run  dyngb-trusty git clone https://github.com/stack-of-tasks/dynamic_graph_bridge.git /repo
 
 script:
 - docker exec dyngb-trusty make /build

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>dynamic_graph_bridge</name>
-  <version>3.0.6</version>
+  <version>3.0.8</version>
   <description>
 
      ROS bindings for dynamic graph.

--- a/scripts/run_command
+++ b/scripts/run_command
@@ -2,12 +2,27 @@
 
 import rospy
 
+import dynamic_graph
 import dynamic_graph_bridge_msgs.srv
-
 import sys
 import code
 from code import InteractiveConsole
-import readline
+
+import os
+
+from dynamic_graph.ros.dgcompleter import DGCompleter
+
+try:
+    import readline
+except ImportError:
+    print("Module readline not available.")
+
+# Enable a History
+HISTFILE="%s/.pyhistory" % os.environ["HOME"]
+
+def savehist():
+    readline.write_history_file(HISTFILE)
+
 
 class RosShell(InteractiveConsole):
     def __init__(self):
@@ -21,6 +36,21 @@ class RosShell(InteractiveConsole):
         rospy.wait_for_service('run_script')
         self.scriptClient = rospy.ServiceProxy(
             'run_script', dynamic_graph_bridge_msgs.srv.RunPythonFile, True)
+        
+        readline.set_completer(DGCompleter(self.client).complete)
+        readline.parse_and_bind("tab: complete")
+
+        # Read the existing history if there is one
+        if os.path.exists(HISTFILE):
+            readline.read_history_file(HISTFILE)
+            
+        # Set maximum number of items that will be written to the history file
+        readline.set_history_length(300)
+            
+ 
+    import atexit
+    atexit.register(savehist)
+
 
     def runcode(self, code, retry = True):
         source = self.cache[:-1]
@@ -36,6 +66,7 @@ class RosShell(InteractiveConsole):
                         self.cache = source
                         return self.runcode(code, False)
                 response = self.client(str(source))
+                print(dir(response))
                 if response.standardoutput != "":
                     print response.standardoutput[:-1]
                 if response.standarderror != "":

--- a/scripts/run_command
+++ b/scripts/run_command
@@ -66,7 +66,6 @@ class RosShell(InteractiveConsole):
                         self.cache = source
                         return self.runcode(code, False)
                 response = self.client(str(source))
-                print(dir(response))
                 if response.standardoutput != "":
                     print response.standardoutput[:-1]
                 if response.standarderror != "":

--- a/src/dynamic_graph/ros/dgcompleter.py
+++ b/src/dynamic_graph/ros/dgcompleter.py
@@ -1,0 +1,87 @@
+"""Word completion for GNU readline.
+
+The completer completes keywords, built-ins and globals in a selectable
+namespace (which defaults to __main__); when completing NAME.NAME..., it
+evaluates (!) the expression up to the last dot and completes its attributes.
+
+It's very cool to do "import sys" type "sys.", hit the completion key (twice),
+and see the list of names defined by the sys module!
+
+Tip: to use the tab key as the completion key, call
+
+    readline.parse_and_bind("tab: complete")
+
+Notes:
+
+- Exceptions raised by the completer function are *ignored* (and generally cause
+  the completion to fail).  This is a feature -- since readline sets the tty
+  device in raw (or cbreak) mode, printing a traceback wouldn't work well
+  without some complicated hoopla to save, reset and restore the tty state.
+
+- The evaluation of the NAME.NAME... form may cause arbitrary application
+  defined code to be executed if an object with a __getattr__ hook is found.
+  Since it is the responsibility of the application (or the user) to enable this
+  feature, I consider this an acceptable risk.  More complicated expressions
+  (e.g. function calls or indexing operations) are *not* evaluated.
+
+- GNU readline is also used by the built-in functions input() and
+raw_input(), and thus these also benefit/suffer from the completer
+features.  Clearly an interactive application can benefit by
+specifying its own completer function and using raw_input() for all
+its input.
+
+- When the original stdin is not a tty device, GNU readline is never
+  used, and this module (and the readline module) are silently inactive.
+
+"""
+
+import __builtin__
+import __main__
+import ast
+
+__all__ = ["DGCompleter"]
+
+class DGCompleter:
+    def __init__(self, client):
+        """Create a new completer for the command line.
+
+        Completer([client]) -> completer instance.
+        
+        Client is a ROS proxy to dynamic_graph run_command service.
+
+        Completer instances should be used as the completion mechanism of
+        readline via the set_completer() call:
+
+        readline.set_completer(Completer(client).complete)
+        """
+        self.client=client
+        astr="import readline"
+        self.client(astr)
+        astr="from rlcompleter import Completer"
+        self.client(astr)
+        astr="aCompleter=Completer()"
+        self.client(astr)
+        astr="readline.set_completer(aCompleter.complete)"
+        self.client(astr)
+        astr="readline.parse_and_bind(\"tab: complete\")"
+        self.client(astr)
+        
+    def complete(self, text, state):
+        """Return the next possible completion for 'text'.    readline.parse_and_bind("tab: complete")
+
+
+        This is called successively with state == 0, 1, 2, ... until it
+        returns None.  The completion should begin with 'text'.
+
+        """
+        astr="aCompleter.complete(\""+text+"\","+str(state)+")"
+        response=self.client(astr);
+        res2=ast.literal_eval(response.result)
+        return res2
+    
+        
+        
+        
+
+
+

--- a/travis_custom/Dockerfile
+++ b/travis_custom/Dockerfile
@@ -1,0 +1,32 @@
+# Pull ros docker image
+FROM ros:indigo-ros-base
+
+# Prepapre sudo environment
+RUN apt-get update && \
+      apt-get -y install sudo && \
+      apt-get -y install curl
+
+RUN useradd -m docker && echo "docker:docker" | chpasswd && adduser docker sudo
+
+USER root
+ADD /travis_custom/sudoers.txt /etc/sudoers
+RUN chmod 440 /etc/sudoers
+
+USER docker
+CMD /bin/bash
+
+# Add robotpkg binary repo
+
+RUN sudo sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list "
+RUN sudo sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list "
+
+RUN curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -
+
+# Update the reference to packages
+RUN sudo apt-get update
+RUN more /etc/apt/sources.list
+# 
+RUN sudo apt-get install -y cppcheck doxygen libboost-system-dev libboost-test-dev libboost-filesystem-dev libboost-program-options-dev libeigen3-dev libtinyxml-dev
+RUN sudo apt-get install -y robotpkg-dynamic-graph-v3 robotpkg-py27-dynamic-graph-v3
+RUN sudo apt-get install -y robotpkg-sot-core-v3 libboost-python-dev robotpkg-py27-eigenpy python2.7-dev python-numpy python-sphinx
+

--- a/travis_custom/sudoers.txt
+++ b/travis_custom/sudoers.txt
@@ -1,0 +1,4 @@
+root ALL=(ALL) ALL
+docker ALL=(ALL) NOPASSWD: ALL
+Defaults    env_reset
+Defaults    secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
After testing (and failing) to include a IPython kernel in our remote interpreter, this pull request proposes to send requests over ROS which is mimicking rlcompleter module for python.
In addition the pull request adds a local history file.

TODO: Display helps for the method + Makes a widget out of this.