### PR TITLE
Fix clean up, ROS services and dangling RosJointState imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,9 @@ ENDIF(BUILD_PYTHON_INTERFACE)
 
 # Stand alone embedded intepreter with a robot controller.
 add_executable(geometric_simu src/geometric_simu.cpp src/sot_loader.cpp src/sot_loader_basic.cpp)
-pkg_config_use_dependency(geometric_simu roscpp tf)
+pkg_config_use_dependency(geometric_simu tf)
+pkg_config_use_dependency(geometric_simu roscpp)
+pkg_config_use_dependency(geometric_simu dynamic-graph)
 target_link_libraries(geometric_simu  ros_bridge tf ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
 
 # Sot loader library

--- a/include/dynamic_graph_bridge/sot_loader.hh
+++ b/include/dynamic_graph_bridge/sot_loader.hh
@@ -24,7 +24,6 @@
 #define _SOT_LOADER_HH_
 
 // System includes
-#include <iostream>
 #include <cassert>
 
 // STL includes

--- a/include/dynamic_graph_bridge/sot_loader_basic.hh
+++ b/include/dynamic_graph_bridge/sot_loader_basic.hh
@@ -24,7 +24,6 @@
 #define _SOT_LOADER_BASIC_HH_
 
 // System includes
-#include <iostream>
 #include <cassert>
 
 // STL includes

--- a/include/dynamic_graph_bridge/sot_loader_basic.hh
+++ b/include/dynamic_graph_bridge/sot_loader_basic.hh
@@ -73,6 +73,12 @@ protected:
   /// \brief Coefficient between parallel joints and the state vector.
   std::vector<double> coefficient_parallel_joints_;
 
+  /// Advertises start_dynamic_graph services
+  ros::ServiceServer service_start_;
+
+  /// Advertises stop_dynamic_graph services
+  ros::ServiceServer service_stop_;
+
   // Joint state publication.
   ros::Publisher joint_pub_;
   
@@ -82,7 +88,6 @@ protected:
   // Number of DOFs according to KDL.
   int nbOfJoints_;
   parallel_joints_to_state_vector_t::size_type nbOfParallelJoints_;
-
 
 public:
   SotLoaderBasic();

--- a/src/dynamic_graph/ros/__init__.py
+++ b/src/dynamic_graph/ros/__init__.py
@@ -1,9 +1,6 @@
 from dynamic_graph.sot.dynamics_pinocchio import DynamicPinocchio
 from ros_publish import RosPublish
 from ros_subscribe import RosSubscribe
-from ros_joint_state import RosJointState
-
-from ros import Ros
 
 # aliases, for retro compatibility
 from ros import RosPublish as RosImport

--- a/src/dynamic_graph/ros/ros.py
+++ b/src/dynamic_graph/ros/ros.py
@@ -1,6 +1,5 @@
 from ros_publish import RosPublish
 from ros_subscribe import RosSubscribe
-from ros_joint_state import RosJointState
 from ros_time import RosTime
 
 from dynamic_graph import plug
@@ -9,7 +8,6 @@ class Ros(object):
     device = None
     rosPublish = None
     rosSubscribe = None
-    rosJointState = None
 
     # aliases, for retro compatibility
     rosImport = None
@@ -19,15 +17,10 @@ class Ros(object):
         self.robot = robot
         self.rosPublish = RosPublish('rosPublish{0}'.format(suffix))
         self.rosSubscribe = RosSubscribe('rosSubscribe{0}'.format(suffix))
-        self.rosJointState = RosJointState('rosJointState{0}'.format(suffix))
-        self.rosJointState.retrieveJointNames(self.robot.dynamic.name)
         self.rosTime = RosTime ('rosTime{0}'.format(suffix))
 
-        plug(self.robot.device.state, self.rosJointState.state)
         self.robot.device.after.addSignal(
             '{0}.trigger'.format(self.rosPublish.name))
-        self.robot.device.after.addSignal(
-            '{0}.trigger'.format(self.rosJointState.name))
 
         # aliases, for retro compatibility
         self.rosImport=self.rosPublish

--- a/src/geometric_simu.cpp
+++ b/src/geometric_simu.cpp
@@ -16,7 +16,6 @@
  * have received a copy of the GNU Lesser General Public License along
  * with dynamic_graph_bridge.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <iostream>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/condition.hpp>
 

--- a/src/ros_publish.hh
+++ b/src/ros_publish.hh
@@ -1,6 +1,5 @@
 #ifndef DYNAMIC_GRAPH_ROS_PUBLISH_HH
 # define DYNAMIC_GRAPH_ROS_PUBLISH_HH
-# include <iostream>
 # include <map>
 
 # include <boost/shared_ptr.hpp>

--- a/src/ros_publish.hxx
+++ b/src/ros_publish.hxx
@@ -8,8 +8,6 @@
 
 # include "sot_to_ros.hh"
 
-# include <iostream>
-
 namespace dynamicgraph
 {
   template <>

--- a/src/ros_queued_subscribe.hh
+++ b/src/ros_queued_subscribe.hh
@@ -19,7 +19,6 @@
 
 #ifndef DYNAMIC_GRAPH_ROS_QUEUED_SUBSCRIBE_HH
 # define DYNAMIC_GRAPH_ROS_QUEUED_SUBSCRIBE_HH
-# include <iostream>
 # include <map>
 
 # include <boost/shared_ptr.hpp>

--- a/src/ros_subscribe.hh
+++ b/src/ros_subscribe.hh
@@ -1,6 +1,5 @@
 #ifndef DYNAMIC_GRAPH_ROS_SUBSCRIBE_HH
 # define DYNAMIC_GRAPH_ROS_SUBSCRIBE_HH
-# include <iostream>
 # include <map>
 
 # include <boost/shared_ptr.hpp>

--- a/src/sot_loader_basic.cpp
+++ b/src/sot_loader_basic.cpp
@@ -35,24 +35,6 @@ using namespace std;
 using namespace dynamicgraph::sot; 
 namespace po = boost::program_options;
 
-void createRosSpin(SotLoaderBasic *aSotLoaderBasic)
-{
-  ROS_INFO("createRosSpin started\n");
-  ros::NodeHandle n;
-
-  ros::ServiceServer service = n.advertiseService("start_dynamic_graph",
-                                                  &SotLoaderBasic::start_dg,
-                                                  aSotLoaderBasic);
-
-  ros::ServiceServer service2 = n.advertiseService("stop_dynamic_graph",
-                                                  &SotLoaderBasic::stop_dg,
-                                                  aSotLoaderBasic);
-
-
-  ros::waitForShutdown();
-}
-
-
 SotLoaderBasic::SotLoaderBasic():
   dynamic_graph_stopped_(true),
   sotRobotControllerLibrary_(0)
@@ -76,8 +58,15 @@ int SotLoaderBasic::initPublication()
 void SotLoaderBasic::initializeRosNode(int , char *[])
 {
   ROS_INFO("Ready to start dynamic graph.");
-  boost::unique_lock<boost::mutex> lock(mut);
-  boost::thread thr2(createRosSpin,this);
+  ros::NodeHandle n;
+
+  service_start_ = n.advertiseService("start_dynamic_graph",
+                                     &SotLoaderBasic::start_dg,
+                                     this);
+
+  service_stop_  = n.advertiseService("stop_dynamic_graph",
+                                     &SotLoaderBasic::stop_dg,
+                                     this);
 
 }   
 

--- a/src/sot_loader_basic.cpp
+++ b/src/sot_loader_basic.cpp
@@ -214,6 +214,25 @@ void SotLoaderBasic::Initialization()
 void SotLoaderBasic::CleanUp()
 {
   dynamicgraph::PoolStorage::destroy();
+  // We do not destroy the FactoryStorage singleton because the module will not
+  // be reloaded at next initialization (because Python C API cannot safely
+  // unload a module...).
+  // SignalCaster singleton could probably be destroyed.
+
+  // Load the symbols.
+  destroySotExternalInterface_t * destroySot =
+    reinterpret_cast<destroySotExternalInterface_t *> 
+    (reinterpret_cast<long> 
+     (dlsym(sotRobotControllerLibrary_, 
+	    "destroySotExternalInterface")));
+  const char* dlsym_error = dlerror();
+  if (dlsym_error) {
+    std::cerr << "Cannot load symbol destroy: " << dlsym_error << '\n';
+    return ;
+  }
+
+  destroySot (sotController_);
+  sotController_ = NULL;
 
   /// Uncount the number of access to this library.
   dlclose(sotRobotControllerLibrary_);

--- a/src/sot_loader_basic.cpp
+++ b/src/sot_loader_basic.cpp
@@ -23,6 +23,8 @@
 #include <dynamic_graph_bridge/sot_loader.hh>
 #include "dynamic_graph_bridge/ros_init.hh"
 
+#include <dynamic-graph/pool.h>
+
 // POSIX.1-2001
 #include <dlfcn.h>
 
@@ -211,6 +213,8 @@ void SotLoaderBasic::Initialization()
 
 void SotLoaderBasic::CleanUp()
 {
+  dynamicgraph::PoolStorage::destroy();
+
   /// Uncount the number of access to this library.
   dlclose(sotRobotControllerLibrary_);
 }


### PR DESCRIPTION
##  Clean up

Entities are all deleted on clean up.

##  RosJointState

If I remember well, this has been removed.

##  ROS thread

If I understand well, there is no need to start the ros::AsyncSpinner in a seperated thread as the services and topics will anyway be not called in the thread creating the spinner.

Moreover, the call `ros::waitForShutdown();` makes it run for ever which prevents unloading of the controller.