### PR TITLE
 Avoid overflow in ros::Duration 

### DIFF
--- a/src/ros_publish.cpp
+++ b/src/ros_publish.cpp
@@ -220,9 +220,10 @@ namespace dynamicgraph
     }
 
     //lock the mutex to avoid deleting the signal during a call to trigger
+    boost::mutex::scoped_lock lock (mutex_);
+
     signalDeregistration(signal);
     bindedSignal_.erase (signal);
-    mutex_.unlock();
   }
 
   std::string RosPublish::list () const
@@ -262,13 +263,14 @@ namespace dynamicgraph
 
     nextPublication_ = ros::Time::now() + rate_;
 
+    boost::mutex::scoped_lock lock (mutex_);
+
     while(! mutex_.try_lock() ){}
     for (iterator_t it = bindedSignal_.begin ();
 	 it != bindedSignal_.end (); ++it)
       {
 	boost::get<1>(it->second) (t);
       }
-    mutex_.unlock();
     return dummy;
   }
 

--- a/src/ros_publish.hh
+++ b/src/ros_publish.hh
@@ -4,7 +4,7 @@
 
 # include <boost/shared_ptr.hpp>
 # include <boost/tuple/tuple.hpp>
-# include <boost/interprocess/sync/interprocess_mutex.hpp>
+# include <boost/thread/mutex.hpp>
 
 # include <dynamic-graph/entity.h>
 # include <dynamic-graph/signal-time-dependent.h>
@@ -94,7 +94,7 @@ namespace dynamicgraph
     dynamicgraph::SignalTimeDependent<int,int> trigger_;
     ros::Duration rate_;
     ros::Time nextPublication_;
-    boost::interprocess::interprocess_mutex mutex_;
+    boost::mutex mutex_;
   };
 } // end of namespace dynamicgraph.
 

--- a/src/ros_publish.hh
+++ b/src/ros_publish.hh
@@ -93,7 +93,7 @@ namespace dynamicgraph
     std::map<std::string, bindedSignal_t> bindedSignal_;
     dynamicgraph::SignalTimeDependent<int,int> trigger_;
     ros::Duration rate_;
-    ros::Time lastPublicated_;
+    ros::Time nextPublication_;
     boost::interprocess::interprocess_mutex mutex_;
   };
 } // end of namespace dynamicgraph.


### PR DESCRIPTION
This was triggerring an exception "Duration is out of dual 32-bit range"