### PR TITLE
[SotLoaderBasic] parseOptions does not call initialization anymore.

### DIFF
--- a/src/geometric_simu.cpp
+++ b/src/geometric_simu.cpp
@@ -21,7 +21,11 @@ int main(int argc, char *argv[]) {
   SotLoader aSotLoader;
   if (aSotLoader.parseOptions(argc, argv) < 0) return -1;
 
+  // Advertize service "(start|stop)_dynamic_graph" and
+  // load parameter "robot_description in SoT.
   aSotLoader.initializeRosNode(argc, argv);
+  // Load dynamic library and run python prologue.
+  aSotLoader.Initialization();
 
   ros::waitForShutdown ();
   return 0;

--- a/src/sot_loader_basic.cpp
+++ b/src/sot_loader_basic.cpp
@@ -129,7 +129,6 @@ int SotLoaderBasic::parseOptions(int argc, char* argv[]) {
   } else
     dynamicLibraryName_ = vm_["input-file"].as<string>();
 
-  Initialization();
   return 0;
 }
 


### PR DESCRIPTION
  - initialization() should be called after initializeRosNode() since the
    former stores ROS parameter "/robot_description" in
    sot::sgl_map_name_to_robot_util (sot/tools/robot-utils.cpp), while the
    second sends the python prologue to the interpreter, and the prologue
    needs the parameter server to contain key "/robot_description".

This pull request solves #79. It has been tested on "master" branch.