### PR TITLE
[fix] Geometric simulation

### DIFF
--- a/src/geometric_simu.cpp
+++ b/src/geometric_simu.cpp
@@ -19,9 +19,9 @@ int main(int argc, char *argv[]) {
 
   ros::init(argc, argv, "sot_ros_encapsulator");
   SotLoader aSotLoader;
-  if (aSotLoader.parseOptions(argc, argv) < 0) return -1;
-
   aSotLoader.initializeRosNode(argc, argv);
+  
+  if (aSotLoader.parseOptions(argc, argv) < 0) return -1;
 
   ros::waitForShutdown ();
   return 0;


### PR DESCRIPTION
Parsing the arguments given to the SoT implies an access to the
list of robots inside the SoT (due to a change in the ParameterServer in
sot-core), which is empty at the moment.
Initializing the ROS node creates the robot inside the SoT, without meaningful
side-effects.

Therefore, this simple fix swaps those two steps.