### PR TITLE
Methods to check whether queue received data

### DIFF
--- a/src/ros_queued_subscribe-python-module-py.cc
+++ b/src/ros_queued_subscribe-python-module-py.cc
@@ -26,9 +26,12 @@ BOOST_PYTHON_MODULE(wrap) {
            "Whether signals should read values from the queues, and when.",
            bp::args("start_time"))
       .def("queueReceivedData", &dg::RosQueuedSubscribe::queueReceivedData,
-           "Check whether the queue of a given signal has received atleast one data point", 
+           "Check whether the queue of a given signal has received atleast one "
+           "data point",
            bp::args("signal_name"))
-      .def("setQueueReceivedData", &dg::RosQueuedSubscribe::setQueueReceivedData,
-           "Set the data reception status of the queue corresponding to a given signal", 
-           bp::args("signal_name","signal_data_acq_status"));
+      .def("setQueueReceivedData",
+           &dg::RosQueuedSubscribe::setQueueReceivedData,
+           "Set the data reception status of the queue corresponding to a "
+           "given signal",
+           bp::args("signal_name", "signal_data_acq_status"));
 }

--- a/src/ros_queued_subscribe-python-module-py.cc
+++ b/src/ros_queued_subscribe-python-module-py.cc
@@ -24,5 +24,11 @@ BOOST_PYTHON_MODULE(wrap) {
            "Return the queue size of a given signal", bp::args("signal_name"))
       .def("readQueue", &dg::RosQueuedSubscribe::readQueue,
            "Whether signals should read values from the queues, and when.",
-           bp::args("start_time"));
+           bp::args("start_time"))
+      .def("queueReceivedData", &dg::RosQueuedSubscribe::queueReceivedData,
+           "Check whether the queue of a given signal has received atleast one data point", 
+           bp::args("signal_name"))
+      .def("setQueueReceivedData", &dg::RosQueuedSubscribe::setQueueReceivedData,
+           "Set the data reception status of the queue corresponding to a given signal", 
+           bp::args("signal_name","signal_data_acq_status"));
 }

--- a/src/ros_queued_subscribe.cpp
+++ b/src/ros_queued_subscribe.cpp
@@ -147,4 +147,21 @@ void RosQueuedSubscribe::readQueue(int beginReadingAt) {
 }
 
 std::string RosQueuedSubscribe::getDocString() const { return docstring_; }
+
+bool RosQueuedSubscribe::queueReceivedData(const std::string& signal) const{
+  std::map<std::string, bindedSignal_t>::const_iterator _bs = bindedSignal_.find(signal);
+  if (_bs != bindedSignal_.end()) {
+    return _bs->second->receivedData();
+  }
+
+  return false;
+}
+
+void RosQueuedSubscribe::setQueueReceivedData(const std::string& signal, bool status) {
+  std::map<std::string, bindedSignal_t>::const_iterator _bs = bindedSignal_.find(signal);
+  if (_bs != bindedSignal_.end()) {
+    _bs->second->receivedData(status);
+  }
+}
+
 }  // end of namespace dynamicgraph.

--- a/src/ros_queued_subscribe.cpp
+++ b/src/ros_queued_subscribe.cpp
@@ -148,8 +148,9 @@ void RosQueuedSubscribe::readQueue(int beginReadingAt) {
 
 std::string RosQueuedSubscribe::getDocString() const { return docstring_; }
 
-bool RosQueuedSubscribe::queueReceivedData(const std::string& signal) const{
-  std::map<std::string, bindedSignal_t>::const_iterator _bs = bindedSignal_.find(signal);
+bool RosQueuedSubscribe::queueReceivedData(const std::string& signal) const {
+  std::map<std::string, bindedSignal_t>::const_iterator _bs =
+      bindedSignal_.find(signal);
   if (_bs != bindedSignal_.end()) {
     return _bs->second->receivedData();
   }
@@ -157,8 +158,10 @@ bool RosQueuedSubscribe::queueReceivedData(const std::string& signal) const{
   return false;
 }
 
-void RosQueuedSubscribe::setQueueReceivedData(const std::string& signal, bool status) {
-  std::map<std::string, bindedSignal_t>::const_iterator _bs = bindedSignal_.find(signal);
+void RosQueuedSubscribe::setQueueReceivedData(const std::string& signal,
+                                              bool status) {
+  std::map<std::string, bindedSignal_t>::const_iterator _bs =
+      bindedSignal_.find(signal);
   if (_bs != bindedSignal_.end()) {
     _bs->second->receivedData(status);
   }

--- a/src/ros_queued_subscribe.hh
+++ b/src/ros_queued_subscribe.hh
@@ -113,12 +113,12 @@ struct BindedSignal : BindedSignalBase {
 
   /// @brief Returns the value stored in receivedData_ i.e.
   /// whether the signal has received atleast one data point
-  /// or not 
-  bool receivedData() const {return receivedData_;}
+  /// or not
+  bool receivedData() const { return receivedData_; }
 
   /// @brief Set the value of data acquisition status of the signal
-  /// @param status 
-  void receivedData(bool status) {receivedData_ = status;}
+  /// @param status
+  void receivedData(bool status) { receivedData_ = status; }
 
   SignalPtr_t signal;
   /// Index of the next value to be read.

--- a/src/ros_queued_subscribe.hxx
+++ b/src/ros_queued_subscribe.hxx
@@ -82,6 +82,12 @@ void BindedSignal<T, N>::writer(const R& data) {
     last = buffer[backIdx];
     init = true;
   }
+  // Updating the status flag to indicate that the signal
+  // has received atleast one data point.
+  if (!receivedData_) {
+    receivedData_ = true;
+  }
+  
   backIdx = (backIdx + 1) % N;
 }
 

--- a/src/ros_queued_subscribe.hxx
+++ b/src/ros_queued_subscribe.hxx
@@ -87,7 +87,7 @@ void BindedSignal<T, N>::writer(const R& data) {
   if (!receivedData_) {
     receivedData_ = true;
   }
-  
+
   backIdx = (backIdx + 1) % N;
 }
 


### PR DESCRIPTION
This commit addresses the issue which was encountered when the UR10 robot was executing a pointing task.

## Issue
Occasionally, there are instances where the robot fails to execute the planned path (by HPP) after it has been triggered through the RQT widget or the demo_execute method (Path generator class - ur10/pointing in agimus-demos package). This is due to the communication and/or the failure of the Agimus (Finite State Machine) to receive the path

**Terminal Log:**
```
[INFO] [1679566131.604702, 71.358000]: >> supervisor.waitForQueue(1,1.0)
[INFO] [1679566132.620421, 72.370000]: (False, 'Queue part/base_link has received 0 points.')
[INFO] [1679566132.622618, 72.372000]: 
[ERROR] [1679566132.624976, 72.374000]: 'Did not receive the first message for initialization: Queue part/base_link has received 0 points.'
[INFO] [1679566132.627310, 72.376000]: State machine transitioning 'Play':'preempted'-->'Error'
```
## Brief explanation
**Normal scenario:**
During the execution of Play state in the FSM (Agimus), a ROS service request is made to Agimus-hpp to publish one waypoint in the feature topics. 

```
rsp = self.serviceProxies["hpp"]["target"]["publish_first"]()
```
[Link to the above code snippet](https://github.com/agimus/agimus/blob/5b1f2b92b430eace183609fe35bfa42c6207c6f7/src/agimus/path_execution/play_path.py#L194)

As requested by Agimus, Agimus-hpp does publish the requested data in the topics, and the published data in stored in a RosQueuedSubscribe object through the ROS callback mechanism (This object is created in  Supervisor class, Agimus-sot package).

Once requested to publish the data in the relevant topics, Agimus requests Agimus-sot to check whether at-least one data point is present in the queue. The check fails if there is no data point in the queue and Agimus-sot waits for 1 second for the data to be written in the queue. 
```
rsp = self.serviceProxies["agimus"]["sot"]["wait_for_min_queue_size"](1, 1.)
```
[Link to the above code snippet](https://github.com/agimus/agimus/blob/5b1f2b92b430eace183609fe35bfa42c6207c6f7/src/agimus/path_execution/play_path.py#L199)

Normally, no fault is detected during this service query and the code execution continues without any issues. 

It is important to note that during this service callback the size of the queue is calculated.

**Abnormal scenario:**
In this scenario, the check related _wait_for_min_queue_size_ fails (as indicated in the terminal log) and the Agimus (FSM ) goes into Error state.

## Root cause
During the analysis of the abnormal scenario, it was found that the even after the data being published by Agimus-hpp and subsequent writing of the published data in the RosQueuedSubscribe object through callback mechanism, the check for _wait_for_min_queue_size_ fails. 

The corresponding service callback entails finding the size of the queue, which in this scenario is coming to be zero. This is not an expected result because Agimus-hpp is publishing data in the relevant topics which is successfully being written in the queue. This operation will increase the size of queue by 1 (as one data point is published).

But between the time the data is published and the check for _wait_for_min_queue_size_ is done, it was found that there is **_unknown_** read operation on the queue which is reducing the queue size by 1. In this case the queue size becomes zero, because the queue is initialised and Agimus-hpp has published only one data point. This should not happen and the root cause of this is **_not yet known_**.

It was also analysed whether this unknown read operation of the signal is triggered manually through python bindings and this was not the case. 

This scenario is rare and is observed intermittently. In future, further analysis can/should be done to find the root cause.

## Proposed Fix
Even though the root cause is unknown, the check implemented in Agimus is not robust i.e. instead of querying for the size of the queue, we can monitor the status of data reception - whether queue has received any data or not.

It is also important to note that this check is done only once at the beginning of the path execution, when the queues are initialised and thus monitoring the status flag is more sensible and robust than querying the size of the queue.

This modification/fix requires update in four packages: dynamic_graph_bridge, agimus_sot_msgs, agimus and agimus-sot.

## Updates in dynamic_graph_bridge
**ros_queued_subscribe.hh**
Added members variables and methods to check if the signal has received atleast one data point and also to reset the data reception status

**ros_queued_subscribe.cpp**
Added methods to check if the RosQueuedSubscribe entity has received atleast one data point and also to manually set the data reception status

**ros_queued_subscribe.hxx**
Add a status flag to indicate that the signal has received atleast one data point

**ros_queued_subscribe-python-module-py.cc**
Python bindings for the newly added methods in RosQueuedSubscribe class